### PR TITLE
Beat unique fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 1.0.0
 commit = True
 tag = True
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   sdist:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     services:
       redis:

--- a/celery_heimdall/__init__.py
+++ b/celery_heimdall/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ('HeimdallTask', 'AlreadyQueuedError', 'RateLimit', 'Strategy')
+__all__ = ("HeimdallTask", "AlreadyQueuedError", "RateLimit", "Strategy")
 
 from celery_heimdall.task import HeimdallTask, RateLimit, Strategy
 from celery_heimdall.errors import AlreadyQueuedError

--- a/celery_heimdall/config.py
+++ b/celery_heimdall/config.py
@@ -9,32 +9,32 @@ class Config:
 
     def _from_task_or_app(self, key, default):
         if self.task:
-            v = getattr(self.task, 'heimdall', {}).get(key)
+            v = getattr(self.task, "heimdall", {}).get(key)
             if v is not None:
                 return v
 
-        return self.app.conf.get(f'heimdall_{key}', default)
+        return self.app.conf.get(f"heimdall_{key}", default)
 
     @property
     def unique_lock_timeout(self):
-        return self._from_task_or_app('unique_lock_timeout', 1)
+        return self._from_task_or_app("unique_lock_timeout", 1)
 
     @property
     def unique_lock_blocking(self):
-        return self._from_task_or_app('unique_lock_blocking', True)
+        return self._from_task_or_app("unique_lock_blocking", True)
 
     @property
     def unique_timeout(self):
-        return self._from_task_or_app('unique_timeout', 60 * 60)
+        return self._from_task_or_app("unique_timeout", 60 * 60)
 
     @property
     def lock_prefix(self):
-        return self._from_task_or_app('lock_prefix', 'h-lock:')
+        return self._from_task_or_app("lock_prefix", "h-lock:")
 
     @property
     def rate_limit_prefix(self):
-        return self._from_task_or_app('rate_limit_prefix', 'h-rate:')
+        return self._from_task_or_app("rate_limit_prefix", "h-rate:")
 
     @property
     def unique_raises(self):
-        return self._from_task_or_app('unique_raises', False)
+        return self._from_task_or_app("unique_raises", False)

--- a/celery_heimdall/contrib/inspector/cli.py
+++ b/celery_heimdall/contrib/inspector/cli.py
@@ -13,24 +13,22 @@ def cli():
     """
 
 
-@cli.command('monitor')
-@click.argument('broker_url')
+@cli.command("monitor")
+@click.argument("broker_url")
 @click.option(
-    '--enable-events',
+    "--enable-events",
     default=False,
     is_flag=True,
     help=(
-        'Sends a command-and-control message to all Celery workers to start'
-        ' emitting worker events before starting the server.'
-    )
+        "Sends a command-and-control message to all Celery workers to start"
+        " emitting worker events before starting the server."
+    ),
 )
 @click.option(
-    '--db',
-    default='heimdall.db',
+    "--db",
+    default="heimdall.db",
     type=click.Path(dir_okay=False, writable=True, path_type=Path),
-    help=(
-        'Use the provided path to store our sqlite database.'
-    )
+    help=("Use the provided path to store our sqlite database."),
 )
 def monitor_command(broker_url: str, enable_events: bool, db: Path):
     """
@@ -47,5 +45,5 @@ def monitor_command(broker_url: str, enable_events: bool, db: Path):
     monitor(broker=broker_url, db=db)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/celery_heimdall/contrib/inspector/models.py
+++ b/celery_heimdall/contrib/inspector/models.py
@@ -8,7 +8,7 @@ from sqlalchemy import (
     func,
     BigInteger,
     text,
-    Enum
+    Enum,
 )
 from sqlalchemy.orm import declarative_base, sessionmaker
 
@@ -36,7 +36,7 @@ class TaskStatus(enum.Enum):
 
 
 class TaskInstance(Base):
-    __tablename__ = 'task_instance'
+    __tablename__ = "task_instance"
 
     uuid = Column(String, primary_key=True)
     name = Column(String)
@@ -53,18 +53,18 @@ class TaskInstance(Base):
     rejected = Column(TIMESTAMP, nullable=True)
     succeeded = Column(TIMESTAMP, nullable=True)
 
-    retries = Column(Integer, server_default=text('0'))
+    retries = Column(Integer, server_default=text("0"))
     last_seen = Column(TIMESTAMP, server_onupdate=func.now())
 
 
 class Worker(Base):
-    __tablename__ = 'worker'
+    __tablename__ = "worker"
 
     #: The hostname of a worker is used as its ID.
     id = Column(String, primary_key=True)
 
     #: How often the worker is configured to send heartbeats.
-    frequency = Column(Integer, server_default=text('0'))
+    frequency = Column(Integer, server_default=text("0"))
     #: Name of the worker software
     sw_identity = Column(String, nullable=True)
     #: Version of the worker software.
@@ -73,9 +73,9 @@ class Worker(Base):
     sw_system = Column(String, nullable=True)
 
     #: Number of currently executing tasks.
-    active = Column(BigInteger, server_default=text('0'))
+    active = Column(BigInteger, server_default=text("0"))
     #: Number of processed tasks.
-    processed = Column(BigInteger, server_default=text('0'))
+    processed = Column(BigInteger, server_default=text("0"))
 
     #: Last known status of the worker.
     status = Column(Enum(WorkerStatus))

--- a/celery_heimdall/contrib/inspector/monitor.py
+++ b/celery_heimdall/contrib/inspector/monitor.py
@@ -12,15 +12,13 @@ def task_received(event):
     with models.Session() as session:
         session.execute(
             insert(models.TaskInstance.__table__).values(
-                uuid=event['uuid'],
-                name=event['name'],
+                uuid=event["uuid"],
+                name=event["name"],
                 status=models.TaskStatus.RECEIVED,
-                hostname=event['hostname'],
-                args=event['args'],
-                kwargs=event['kwargs'],
-                received=datetime.datetime.fromtimestamp(
-                    event['timestamp']
-                )
+                hostname=event["hostname"],
+                args=event["args"],
+                kwargs=event["kwargs"],
+                received=datetime.datetime.fromtimestamp(event["timestamp"]),
             )
         )
         session.commit()
@@ -29,17 +27,13 @@ def task_received(event):
 def task_started(event):
     with models.Session() as session:
         session.execute(
-            update(
-                models.TaskInstance.__table__
-            ).where(
-                models.TaskInstance.uuid == event['uuid']
-            ).values(
-                runtime=event.get('runtime', 0),
+            update(models.TaskInstance.__table__)
+            .where(models.TaskInstance.uuid == event["uuid"])
+            .values(
+                runtime=event.get("runtime", 0),
                 status=models.TaskStatus.STARTED,
-                started=datetime.datetime.fromtimestamp(
-                    event['timestamp']
-                ),
-                last_seen=func.now()
+                started=datetime.datetime.fromtimestamp(event["timestamp"]),
+                last_seen=func.now(),
             )
         )
         session.commit()
@@ -48,17 +42,13 @@ def task_started(event):
 def task_succeeded(event):
     with models.Session() as session:
         session.execute(
-            update(
-                models.TaskInstance.__table__
-            ).where(
-                models.TaskInstance.uuid == event['uuid']
-            ).values(
-                runtime=event.get('runtime', 0),
+            update(models.TaskInstance.__table__)
+            .where(models.TaskInstance.uuid == event["uuid"])
+            .values(
+                runtime=event.get("runtime", 0),
                 status=models.TaskStatus.SUCCEEDED,
-                succeeded=datetime.datetime.fromtimestamp(
-                    event['timestamp']
-                ),
-                last_seen=func.now()
+                succeeded=datetime.datetime.fromtimestamp(event["timestamp"]),
+                last_seen=func.now(),
             )
         )
         session.commit()
@@ -67,15 +57,13 @@ def task_succeeded(event):
 def task_retried(event):
     with models.Session() as session:
         session.execute(
-            update(
-                models.TaskInstance.__table__
-            ).where(
-                models.TaskInstance.uuid == event['uuid']
-            ).values(
-                runtime=event.get('runtime', 0),
+            update(models.TaskInstance.__table__)
+            .where(models.TaskInstance.uuid == event["uuid"])
+            .values(
+                runtime=event.get("runtime", 0),
                 status=models.TaskStatus.RETRIED,
                 retries=models.TaskInstance.retries + 1,
-                last_seen=func.now()
+                last_seen=func.now(),
             )
         )
         session.commit()
@@ -84,17 +72,13 @@ def task_retried(event):
 def task_failed(event):
     with models.Session() as session:
         session.execute(
-            update(
-                models.TaskInstance.__table__
-            ).where(
-                models.TaskInstance.uuid == event['uuid']
-            ).values(
-                runtime=event.get('runtime', 0),
+            update(models.TaskInstance.__table__)
+            .where(models.TaskInstance.uuid == event["uuid"])
+            .values(
+                runtime=event.get("runtime", 0),
                 status=models.TaskStatus.FAILED,
-                failed=datetime.datetime.fromtimestamp(
-                    event['timestamp']
-                ),
-                last_seen=func.now()
+                failed=datetime.datetime.fromtimestamp(event["timestamp"]),
+                last_seen=func.now(),
             )
         )
         session.commit()
@@ -103,17 +87,13 @@ def task_failed(event):
 def task_rejected(event):
     with models.Session() as session:
         session.execute(
-            update(
-                models.TaskInstance.__table__
-            ).where(
-                models.TaskInstance.uuid == event['uuid']
-            ).values(
-                runtime=event.get('runtime', 0),
+            update(models.TaskInstance.__table__)
+            .where(models.TaskInstance.uuid == event["uuid"])
+            .values(
+                runtime=event.get("runtime", 0),
                 status=models.TaskStatus.REJECTED,
-                rejected=datetime.datetime.fromtimestamp(
-                    event['timestamp']
-                ),
-                last_seen=func.now()
+                rejected=datetime.datetime.fromtimestamp(event["timestamp"]),
+                last_seen=func.now(),
             )
         )
         session.commit()
@@ -121,21 +101,21 @@ def task_rejected(event):
 
 def worker_event(event):
     field_mapping = {
-        'freq': models.Worker.frequency,
-        'sw_ident': models.Worker.sw_identity,
-        'sw_ver': models.Worker.sw_version,
-        'sw_sys': models.Worker.sw_system,
-        'active': models.Worker.active,
-        'processed': models.Worker.processed
+        "freq": models.Worker.frequency,
+        "sw_ident": models.Worker.sw_identity,
+        "sw_ver": models.Worker.sw_version,
+        "sw_sys": models.Worker.sw_system,
+        "active": models.Worker.active,
+        "processed": models.Worker.processed,
     }
 
     payload = {
-        'last_seen': func.now(),
-        'status': {
-            'worker-heartbeat': models.WorkerStatus.ALIVE,
-            'worker-online': models.WorkerStatus.ALIVE,
-            'worker-offline': models.WorkerStatus.OFFLINE,
-        }.get(event['type'], models.WorkerStatus.LOST)
+        "last_seen": func.now(),
+        "status": {
+            "worker-heartbeat": models.WorkerStatus.ALIVE,
+            "worker-online": models.WorkerStatus.ALIVE,
+            "worker-offline": models.WorkerStatus.OFFLINE,
+        }.get(event["type"], models.WorkerStatus.LOST),
     }
     for k, v in field_mapping.items():
         if k in event:
@@ -144,13 +124,9 @@ def worker_event(event):
     # FIXME: Support postgres / MySQL
     with models.Session() as session:
         session.execute(
-            insert(models.Worker.__table__).values({
-                'id': event['hostname'],
-                **payload
-            }).on_conflict_do_update(
-                index_elements=['id'],
-                set_=payload
-            )
+            insert(models.Worker.__table__)
+            .values({"id": event["hostname"], **payload})
+            .on_conflict_do_update(index_elements=["id"], set_=payload)
         )
         session.commit()
 
@@ -162,7 +138,7 @@ def monitor(*, broker: str, db: Path):
     """
     app = Celery(broker=broker)
 
-    engine = create_engine(f'sqlite:///{db}')
+    engine = create_engine(f"sqlite:///{db}")
     models.Session.configure(bind=engine)
     models.Base.metadata.create_all(engine)
 
@@ -171,15 +147,15 @@ def monitor(*, broker: str, db: Path):
             connection,
             handlers={
                 # '*': state.event,
-                'task-started': task_started,
-                'task-rejected': task_rejected,
-                'task-failed': task_failed,
-                'task-received': task_received,
-                'task-succeeded': task_succeeded,
-                'task-retried': task_retried,
-                'worker-online': worker_event,
-                'worker-heartbeat': worker_event,
-                'worker-offline': worker_event
-            }
+                "task-started": task_started,
+                "task-rejected": task_rejected,
+                "task-failed": task_failed,
+                "task-received": task_received,
+                "task-succeeded": task_succeeded,
+                "task-retried": task_retried,
+                "worker-online": worker_event,
+                "worker-heartbeat": worker_event,
+                "worker-offline": worker_event,
+            },
         )
         recv.capture(limit=None, timeout=None, wakeup=True)

--- a/celery_heimdall/errors.py
+++ b/celery_heimdall/errors.py
@@ -12,15 +12,20 @@ class AlreadyQueuedError(Exception):
     `likely_culprit` is here to assist in debugging deadlocks. Retrieving this
     value is not atomic, and thus should not be relied upon.
     """
-    def __init__(self, *, expires_in: Optional[int] = None,
-                 likely_culprit: Optional[str] = None):
+
+    def __init__(
+        self,
+        *,
+        expires_in: Optional[int] = None,
+        likely_culprit: Optional[str] = None,
+    ):
         super().__init__()
         self.likely_culprit = likely_culprit
         self.expires_in = expires_in
 
     def __repr__(self):
         return (
-            '<AlreadyQueuedError('
-            f'likely_culprit={self.likely_culprit!r},'
-            f' expires_in={self.expires_in!r})>'
+            "<AlreadyQueuedError("
+            f"likely_culprit={self.likely_culprit!r},"
+            f" expires_in={self.expires_in!r})>"
         )

--- a/celery_heimdall/task.py
+++ b/celery_heimdall/task.py
@@ -26,7 +26,7 @@ class RateLimit:
     strategy: Strategy = Strategy.DEFAULT
 
 
-def acquire_lock(task: 'HeimdallTask', key: str, timeout: int, *, task_id: str):
+def acquire_lock(task: "HeimdallTask", key: str, timeout: int, *, task_id: str):
     acquired = redis.lock.Lock(
         task.heimdall_redis,
         key,
@@ -45,23 +45,24 @@ def acquire_lock(task: 'HeimdallTask', key: str, timeout: int, *, task_id: str):
             # TTL may be -1 or -2 if the key didn't exist, depending on the
             # version of Redis.
             expires_in=max(0, ttl),
-            likely_culprit=task_id.decode('utf-8') if task_id else None
+            likely_culprit=task_id.decode("utf-8") if task_id else None,
         )
 
     return acquired
 
 
-def release_lock(task: 'HeimdallTask', key: str):
+def release_lock(task: "HeimdallTask", key: str):
     task.heimdall_redis.delete(key)
 
 
-def unique_key_for_task(task: 'HeimdallTask', args, kwargs, *,
-                        prefix='') -> str:
+def unique_key_for_task(
+    task: "HeimdallTask", args, kwargs, *, prefix=""
+) -> str:
     """
     Given a task and its arguments, generate a unique key which can be used
     to identify it.
     """
-    h = getattr(task, 'heimdall', {})
+    h = getattr(task, "heimdall", {})
 
     # When Celery deserializes the arguments for a job, args and kwargs will
     # be `[]` or `{}`, even if they were `None` when serialized. Ensure we
@@ -70,10 +71,10 @@ def unique_key_for_task(task: 'HeimdallTask', args, kwargs, *,
     kwargs = kwargs or {}
 
     # User specified an explicit key function.
-    if 'key' in h:
-        if callable(h['key']):
-            return prefix + h['key'](args, kwargs)
-        return prefix + h['key']
+    if "key" in h:
+        if callable(h["key"]):
+            return prefix + h["key"](args, kwargs)
+        return prefix + h["key"]
 
     # Try to generate a unique key from the arguments given to the task.
     # Most of the cases where this will fail are also cases where Celery
@@ -82,41 +83,41 @@ def unique_key_for_task(task: 'HeimdallTask', args, kwargs, *,
     _, _, data = serialization.dumps(
         (args, kwargs),
         # TODO: We should _probably_ use the same serializer as the task.
-        'json'
+        "json",
     )
 
     h = hashlib.md5()
-    h.update(task.name.encode('utf-8'))
-    h.update(data.encode('utf-8'))
-    return f'{prefix}{h.hexdigest()}'
+    h.update(task.name.encode("utf-8"))
+    h.update(data.encode("utf-8"))
+    return f"{prefix}{h.hexdigest()}"
 
 
-def rate_limited_countdown(task: 'HeimdallTask', key, args, kwargs):
+def rate_limited_countdown(task: "HeimdallTask", key, args, kwargs):
     # Based on improvements to Vigrond's original implementation by mlissner
     # on stack overflow.
-    h = getattr(task, 'heimdall', {})
+    h = getattr(task, "heimdall", {})
     r = task.heimdall_redis
 
-    if 'rate_limit' in h:
+    if "rate_limit" in h:
         try:
-            times, per = h['rate_limit'].rate_limit
+            times, per = h["rate_limit"].rate_limit
         except TypeError as e:
-            f = h['rate_limit'].rate_limit
+            f = h["rate_limit"].rate_limit
 
             rate_limit_args = {}
             signature = inspect.signature(f)
-            if 'key' in signature.parameters:
-                rate_limit_args['key'] = key
-            if 'task' in signature.parameters:
-                rate_limit_args['task'] = task
-            if 'args' in signature.parameters:
-                rate_limit_args['args'] = args
-            if 'kwargs' in signature.parameters:
-                rate_limit_args['kwargs'] = kwargs
+            if "key" in signature.parameters:
+                rate_limit_args["key"] = key
+            if "task" in signature.parameters:
+                rate_limit_args["task"] = task
+            if "args" in signature.parameters:
+                rate_limit_args["args"] = args
+            if "kwargs" in signature.parameters:
+                rate_limit_args["kwargs"] = kwargs
 
-            times, per = h['rate_limit'].rate_limit(**rate_limit_args)
+            times, per = h["rate_limit"].rate_limit(**rate_limit_args)
     else:
-        times, per = h['times'], h['per']
+        times, per = h["times"], h["per"]
 
     number_of_running_tasks = r.get(key)
     if number_of_running_tasks is None:
@@ -128,7 +129,7 @@ def rate_limited_countdown(task: 'HeimdallTask', key, args, kwargs):
             r.expire(key, per)
         return 0
 
-    schedule_key = f'{key}.schedule'
+    schedule_key = f"{key}.schedule"
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
     delay = r.get(schedule_key)
@@ -141,16 +142,13 @@ def rate_limited_countdown(task: 'HeimdallTask', key, args, kwargs):
         r.set(
             schedule_key,
             int((now + datetime.timedelta(seconds=ttl)).timestamp()),
-            ex=ttl + 20
+            ex=ttl + 20,
         )
         return ttl
 
-    new_time = (
-        datetime.datetime.fromtimestamp(
-            int(delay),
-            tz=datetime.timezone.utc
-        ) + datetime.timedelta(seconds=per // times)
-    )
+    new_time = datetime.datetime.fromtimestamp(
+        int(delay), tz=datetime.timezone.utc
+    ) + datetime.timedelta(seconds=per // times)
     new_delay = int((new_time - now).total_seconds())
     r.set(schedule_key, int(new_time.timestamp()), ex=new_delay + 20)
     return new_delay
@@ -162,6 +160,7 @@ class HeimdallTask(celery.Task, ABC):
     for common Celery behaviors, such as global rate limiting and singleton
     (only one at a time) tasks.
     """
+
     abstract = True
 
     def __init__(self):
@@ -202,13 +201,13 @@ class HeimdallTask(celery.Task, ABC):
                     return Redis.from_url('redis://')
         """
         # Try to use the Celery result backend, if it's configured for redis.
-        backend = self.app.conf.get('result_backend') or ''
-        if backend.startswith('redis://'):
+        backend = self.app.conf.get("result_backend") or ""
+        if backend.startswith("redis://"):
             return redis.Redis.from_url(backend)
 
         # If not the backend, try the broker....
-        broker = self.app.conf.get('broker_url') or ''
-        if broker.startswith('redis://'):
+        broker = self.app.conf.get("broker_url") or ""
+        if broker.startswith("redis://"):
             return redis.Redis.from_url(broker)
 
         # Nope, we can't find a usable redis, user will need to implement
@@ -216,8 +215,8 @@ class HeimdallTask(celery.Task, ABC):
         raise NotImplementedError()
 
     def apply_async(self, args=None, kwargs=None, task_id=None, **options):
-        h = getattr(self, 'heimdall', {})
-        if h and 'unique' in h:
+        h = getattr(self, "heimdall", {})
+        if h and "unique" in h:
             task_id = task_id or uuid()
 
             # Task has been configured to be globally unique, so we check for
@@ -229,13 +228,12 @@ class HeimdallTask(celery.Task, ABC):
                         self,
                         args,
                         kwargs,
-                        prefix=self.heimdall_config.lock_prefix
+                        prefix=self.heimdall_config.lock_prefix,
                     ),
                     h.get(
-                        'unique_timeout',
-                        self.heimdall_config.unique_timeout
+                        "unique_timeout", self.heimdall_config.unique_timeout
                     ),
-                    task_id=task_id
+                    task_id=task_id,
                 )
             except AlreadyQueuedError as exc:
                 if not self.heimdall_config.unique_raises:
@@ -251,25 +249,22 @@ class HeimdallTask(celery.Task, ABC):
         #       rate-limited task, rather then just checking when it runs.
 
         return super().apply_async(
-            args=args,
-            kwargs=kwargs,
-            task_id=task_id,
-            **options
+            args=args, kwargs=kwargs, task_id=task_id, **options
         )
 
     def __call__(self, *args, **kwargs):
-        h = getattr(self, 'heimdall', {})
-        if h and ('per' in h and 'times' in h) or 'rate_limit' in h:
+        h = getattr(self, "heimdall", {})
+        if h and ("per" in h and "times" in h) or "rate_limit" in h:
             delay = rate_limited_countdown(
                 self,
                 unique_key_for_task(
                     self,
                     args,
                     kwargs,
-                    prefix=self.heimdall_config.rate_limit_prefix
+                    prefix=self.heimdall_config.rate_limit_prefix,
                 ),
                 args,
-                kwargs
+                kwargs,
             )
             if delay > 0:
                 # We don't want our rescheduling retry to count against
@@ -285,7 +280,7 @@ class HeimdallTask(celery.Task, ABC):
         # Normally, we check for uniqueness before calling the task, but if
         # celery beat is being used, it appears to bypass the apply_async
         # method, so we need to check again at run time.
-        if h and 'unique' in h:
+        if h and "unique" in h:
             task_id = self.request.id
             try:
                 acquire_lock(
@@ -294,13 +289,12 @@ class HeimdallTask(celery.Task, ABC):
                         self,
                         args,
                         kwargs,
-                        prefix=self.heimdall_config.lock_prefix
+                        prefix=self.heimdall_config.lock_prefix,
                     ),
                     h.get(
-                        'unique_timeout',
-                        self.heimdall_config.unique_timeout
+                        "unique_timeout", self.heimdall_config.unique_timeout
                     ),
-                    task_id=task_id
+                    task_id=task_id,
                 )
             except AlreadyQueuedError as exc:
                 # If this task is the one holding the lock, we can just
@@ -317,19 +311,16 @@ class HeimdallTask(celery.Task, ABC):
         # Handles post-task cleanup, when a task exits cleanly. This will be
         # called if a task raises an exception (stored in `einfo`), but not
         # if a worker straight up dies (say, because of running out of memory)
-        h = getattr(self, 'heimdall', {})
+        h = getattr(self, "heimdall", {})
 
         # Cleanup the unique task lock when the task finishes, unless the user
         # told us to wait for the remaining interval.
-        if h and 'unique' in h and not h.get('unique_wait_for_expiry'):
+        if h and "unique" in h and not h.get("unique_wait_for_expiry"):
             release_lock(
                 self,
                 unique_key_for_task(
-                    self,
-                    args,
-                    kwargs,
-                    prefix=self.heimdall_config.lock_prefix
-                )
+                    self, args, kwargs, prefix=self.heimdall_config.lock_prefix
+                ),
             )
 
         super().after_return(status, retval, task_id, args, kwargs, einfo)
@@ -343,13 +334,13 @@ class HeimdallTask(celery.Task, ABC):
         in that task you only want to run after at least an hour. You'd use
         `only_after` to accomplish that.
         """
-        task_id = getattr(self.request, 'id', uuid())
+        task_id = getattr(self.request, "id", uuid())
         return bool(
             redis.lock.Lock(
                 self.heimdall_redis,
                 key,
                 timeout=seconds,
                 blocking=self.heimdall_config.unique_lock_blocking,
-                blocking_timeout=self.heimdall_config.unique_lock_timeout
+                blocking_timeout=self.heimdall_config.unique_lock_timeout,
             ).acquire(token=task_id)
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "celery-heimdall"
-version = "0.6.0"
+version = "1.0.0"
 description = "Helpful celery extensions."
 authors = ["Tyler Kennedy <tk@tkte.ch>"]
 license = "MIT"
@@ -18,7 +18,7 @@ importlib-metadata = "<=4.13"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
-bumpversion = "^0.6.0"
+bumpversion = "^1.0.0"
 coverage = "^6.4.4"
 pytest-cov = "^3.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/tktech/celery-heimdall"
 repository = "https://github.com/tktech/celery-heimdall"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 celery = "^5.2.7"
 redis = "^4.3.4"
 click = {version = "^8.1.3", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pytest = "^7.1.2"
 bumpversion = "^0.6.0"
 coverage = "^6.4.4"
 pytest-cov = "^3.0.0"
+black = "^23.9.1"
 
 [tool.poetry.extras]
 inspector = ["click", "sqlalchemy"]
@@ -31,3 +32,6 @@ heimdall-inspector = "celery_heimdall.contrib.inspector.cli:cli"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "celery-heimdall"
-version = "0.5.0"
+version = "0.6.0"
 description = "Helpful celery extensions."
 authors = ["Tyler Kennedy <tk@tkte.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ importlib-metadata = "<=4.13"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
-bumpversion = "^1.0.0"
+bumpversion = "^0.6.0"
 coverage = "^6.4.4"
 pytest-cov = "^3.0.0"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,17 @@
 import pytest
 
-pytest_plugins = ('celery.contrib.pytest', )
+pytest_plugins = ("celery.contrib.pytest",)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def celery_config():
     return {
-        'broker_url': 'redis://',
-        'result_backend': 'redis://',
-        'worker_send_task_events': True
+        "broker_url": "redis://",
+        "result_backend": "redis://",
+        "worker_send_task_events": True,
     }
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def celery_worker_parameters():
-    return {'without_heartbeat': False}
+    return {"without_heartbeat": False}

--- a/tests/test_only_after.py
+++ b/tests/test_only_after.py
@@ -8,7 +8,7 @@ from celery_heimdall import HeimdallTask
 
 @shared_task(base=HeimdallTask, bind=True)
 def task_with_block(self: HeimdallTask):
-    if self.only_after('only_after', 5):
+    if self.only_after("only_after", 5):
         return True
     return False
 

--- a/tests/test_rate_limited.py
+++ b/tests/test_rate_limited.py
@@ -7,42 +7,27 @@ from celery import shared_task
 from celery_heimdall import HeimdallTask, RateLimit
 
 
-@shared_task(
-    base=HeimdallTask,
-    heimdall={
-        'times': 2,
-        'per': 10
-    }
-)
+@shared_task(base=HeimdallTask, heimdall={"times": 2, "per": 10})
 def default_rate_limit_task():
     pass
 
 
-@shared_task(
-    base=HeimdallTask,
-    heimdall={
-        'rate_limit': RateLimit((2, 10))
-    }
-)
+@shared_task(base=HeimdallTask, heimdall={"rate_limit": RateLimit((2, 10))})
 def tuple_rate_limit_task():
     pass
 
 
 @shared_task(
-    base=HeimdallTask,
-    heimdall={
-        'rate_limit': RateLimit(lambda key: (2, 10))
-    }
+    base=HeimdallTask, heimdall={"rate_limit": RateLimit(lambda key: (2, 10))}
 )
 def callable_rate_limit_task():
     pass
 
 
-@pytest.mark.parametrize('func', [
-    default_rate_limit_task,
-    tuple_rate_limit_task,
-    callable_rate_limit_task
-])
+@pytest.mark.parametrize(
+    "func",
+    [default_rate_limit_task, tuple_rate_limit_task, callable_rate_limit_task],
+)
 def test_default_rate_limit(celery_session_worker, func):
     """
     Ensure a unique task with no other configuration "just works".

--- a/tests/test_rate_limited.py
+++ b/tests/test_rate_limited.py
@@ -1,6 +1,5 @@
 import time
 
-import celery.result
 import pytest
 from celery import shared_task
 

--- a/tests/test_unique.py
+++ b/tests/test_unique.py
@@ -47,6 +47,14 @@ def explicit_key_task():
 
 @celery.shared_task(
     base=HeimdallTask,
+    heimdall={"unique": True, "key": "MyTaskKeyStr"},
+)
+def explicit_key_task_str():
+    return
+
+
+@celery.shared_task(
+    base=HeimdallTask,
     bind=True,
     heimdall={"unique": True, "lock_prefix": "new-prefix:"},
 )
@@ -96,6 +104,11 @@ def test_unique_explicit_key(celery_session_worker):
     # again.
     task1.get()
     explicit_key_task.apply_async()
+
+    # Ensure we can use a simple string instead of a lambda.
+    task1: AsyncResult = explicit_key_task_str.apply_async()
+    result: AsyncResult = explicit_key_task_str.apply_async()
+    assert task1.id == result.id
 
 
 def test_different_keys(celery_session_worker):


### PR DESCRIPTION
It's possible for the `celery beat` scheduler to skip calling `apply_async()`, if it's unable to import the actual task. In these cases, it'll resort to using `send_task()`, see https://github.com/celery/celery/blob/main/celery/beat.py#L406. This means that our unique lock may never be checked, since we hook it into `Task.apply_async()`.

This change adds verification of the lock at the time a task is run, while keeping the early lock as well.

This is a known issue with other similar libraries, see:

- https://github.com/cameronmaske/celery-once/issues/136
- https://github.com/steinitzu/celery-singleton/issues/38